### PR TITLE
Add key derivation function binding and appropriate tests

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -2,17 +2,19 @@ extern crate hex;
 extern crate openssl;
 
 // use super::*;
+use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
+use openssl::pkcs5;
 use openssl::pkey::PKey;
 use openssl::sign::Signer;
 use std::string::String;
 
 /*
- * Input: secret key
- *        message to signed
- * Output: signed mac result
+ * Inputs: secret key
+ *        message to sign
+ * Output: signed HMAC result
  *
- * Sign message and return hmac mac string
+ * Sign message and return HMAC result string
  */
 pub fn do_hmac(input_key: String, input_message: String) -> String {
     let key = PKey::hmac(input_key.as_bytes()).unwrap();
@@ -24,8 +26,43 @@ pub fn do_hmac(input_key: String, input_message: String) -> String {
 }
 
 /*
+ * Inputs: password to derive key
+ *         shared salt
+ * Output: derived key
+ *
+ * Take in a password and shared salt, and derive a key based on the
+ * PBKDF2-HMAC key derivation function. Parameters match that of
+ * Python-Keylime.
+ *
+ * NOTE: This uses SHA-1 as the KDF's hash function in order to match the
+ * implementation of PBKDF2 in the Python version of Keylime. PyCryptodome's
+ * PBKDF2 function defaults to SHA-1 unless otherwise specified, and
+ * Python-Keylime uses this default.
+ */
+pub fn kdf(
+    input_password: String,
+    input_salt: String,
+) -> Result<String, ErrorStack> {
+    let password = input_password.as_bytes();
+    let salt = input_salt.as_bytes();
+    let count = 2000;
+    // PyCryptodome's PBKDF2 binding allows key length to be specified
+    // explicitly as a parameter; here, key length is implicitly defined in
+    // the length of the 'key' variable.
+    let mut key = [0; 32];
+    pkcs5::pbkdf2_hmac(
+        password,
+        salt,
+        count,
+        MessageDigest::sha1(),
+        &mut key,
+    )?;
+    Ok(to_hex_string(key.to_vec()))
+}
+
+/*
  * Input: bytes data
- * Output: hex string represenatation of bytes
+ * Output: hex string representation of bytes
  *
  * Convert a byte data to a hex representation
  */
@@ -49,6 +86,16 @@ mod tests {
         let message = String::from("hellothere");
         let mac = do_hmac(key, message);
         assert_eq!("b8558314f515931c8d9b329805978fe77b9bb020b05406c0ef189d89846ff8f5f0ca10e387d2c424358171df7f896f9f".to_string(), mac);
+    }
+
+    // Test KDF to ensure derived password matches result derived from Python
+    // functions.
+    #[test]
+    fn test_kdf() {
+        let password = String::from("myverysecretsecret");
+        let salt = String::from("thesaltiestsalt");
+        let key = kdf(password, salt);
+        assert_eq!("8a6de415abb8b27de5c572c8137bd14e5658395f9a2346e0b1ad8b9d8b9028af".to_string(), key.unwrap());
     }
 
     #[test]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -16,13 +16,16 @@ use std::string::String;
  *
  * Sign message and return HMAC result string
  */
-pub fn do_hmac(input_key: String, input_message: String) -> String {
-    let key = PKey::hmac(input_key.as_bytes()).unwrap();
+pub fn do_hmac(
+    input_key: String,
+    input_message: String,
+) -> Result<String, ErrorStack> {
+    let key = PKey::hmac(input_key.as_bytes())?;
     let message = input_message.as_bytes();
-    let mut signer = Signer::new(MessageDigest::sha384(), &key).unwrap();
-    signer.update(message).unwrap();
-    let hmac = signer.sign_to_vec().unwrap();
-    return to_hex_string(hmac);
+    let mut signer = Signer::new(MessageDigest::sha384(), &key)?;
+    signer.update(message)?;
+    let hmac = signer.sign_to_vec()?;
+    Ok(to_hex_string(hmac))
 }
 
 /*
@@ -85,7 +88,7 @@ mod tests {
         let key = String::from("mysecret");
         let message = String::from("hellothere");
         let mac = do_hmac(key, message);
-        assert_eq!("b8558314f515931c8d9b329805978fe77b9bb020b05406c0ef189d89846ff8f5f0ca10e387d2c424358171df7f896f9f".to_string(), mac);
+        assert_eq!("b8558314f515931c8d9b329805978fe77b9bb020b05406c0ef189d89846ff8f5f0ca10e387d2c424358171df7f896f9f".to_string(), mac.unwrap());
     }
 
     // Test KDF to ensure derived password matches result derived from Python


### PR DESCRIPTION
As the title suggests, this PR adds a binding for the PBKDF2-HMAC function in OpenSSL and configures it to match the [implementation in Python-Keylime](https://github.com/mit-ll/python-keylime/blob/2da18bd4814fb3c93d89175d2d5172b1167753c2/keylime/crypto.py#L83). An appropriate test is also added.

A few notes:

- This is also mentioned in the function documentation, but it bears repeating: The only reason this binding uses SHA-1 is because Python-Keylime uses it at the moment. PyCryptodome [defaults to SHA-1 as a PRF](https://pycryptodome.readthedocs.io/en/latest/src/protocol/kdf.html) if the `prf` parameter is not specified, and Python-Keylime does not provide that parameter in its KDF binding.

- The key the test compares against was generated from the Python-Keylime KDF binding using the same password and salt.

Tagging @frozencemetery and @leonjia0112 for review.