### PR TITLE
Removed all unwraps/panics for all code except testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: rust
+dist: xenial
 
 before_script:
     - rustup component add rustfmt-preview
+
+before_install:
+    - sudo apt-get install -y python3
 
 script:
     - cargo fmt --all -- --check
     - cargo build
     - cargo test
+    - ./.travis/nopanic.py

--- a/.travis/nopanic.py
+++ b/.travis/nopanic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import os
+
+banned = ["unwrap(", "panic!("]
+
+srcs = os.listdir("src")
+print("Files to check: %s" % srcs)
+
+failed = False
+for f in srcs:
+    print("Checking file %s" % f)
+    contents = open("src/%s" % f, "r").read().split("#[cfg(test)]")[0]
+    for b in banned:
+        if b not in contents:
+            continue
+
+        failed = True
+        print("File %s calls banned function: %s)" % (f, b))
+    pass
+
+exit(failed)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ mod crypto;
 mod secure_mount;
 mod tpm;
 
+use common::emsg;
+use common::set_response_content;
 use futures::future;
 use hyper::rt::Future;
 use hyper::service::service_fn;
@@ -44,7 +46,7 @@ fn main() {
     info!("Starting server...");
 
     /* Should be port 3000 eventually */
-    let addr = "127.0.0.1:1337".parse().unwrap();
+    let addr = ([127, 0, 0, 1], 1337).into();
 
     let server = Server::bind(&addr)
         .serve(|| service_fn(response_function))
@@ -57,292 +59,440 @@ fn main() {
 }
 
 fn response_function(req: Request<Body>) -> BoxFut {
-    let res;
+    let mut my_response: Response<Body> =
+        Response::new("Nothing here.".into());
 
-    // need a method to process input api path !!
+    // Process input api path
     let parameters = common::get_restful_parameters(req.uri().path());
 
+    // Loop scope wrap around the request handling
+    // Exit: Encounter error early exit or exit at the end to the scope
     match req.method() {
         &Method::GET => {
-            info!("GET invoded");
-
-            // invalid requestd handling
-            if parameters.is_empty() {
-                res = common::json_response_content(
-                    200,
-                    "Not Implemented: Use /v2/keys/ or /v2/quotes/ interfaces".to_string(),
-                    Map::new(),
-                );
-            } else if parameters.contains_key("keys") {
-                let mut response = Map::new();
-
-                match parameters.get(&"keys") {
-                    // check Kb value is available to perform the do_hmac
-                    // crypto request verify will do hmac for the challenge
-                    // orignal function: crypto.do_hmac(self.server.K,
-                    // challenge)
-                    Some(&"verify") => {
-                        /* /keys/verify/challenge/blablabla */
-                        let challenge = parameters.get(&"challenge");
-                        let result = crypto::do_hmac(
-                            common::KEY.to_string(),
-                            challenge.unwrap().to_string(),
-                        );
-                        match result {
-                            Ok(hmac) => {
-                                info!(
-                                    "
-                                    GET keys/verify challenge returning 200
-                                    response.
-                                    "
-                                );
-                                response.insert("hmac".into(), hmac.into());
-                                res = common::json_response_content(
-                                    200,
-                                    "Success".to_string(),
-                                    response,
-                                );
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "GET keys/verify challenge returning 400
-                                    response. HMAC call failed with error:\n
-                                    {}",
-                                    e
-                                );
-                                res = common::json_response_content(
-                                    400,
-                                    "Bad Request".to_string(),
-                                    Map::new(),
-                                );
-                            }
-                        }
-                    }
-
-                    // pubkey export the rsa pub key
-                    // original: self.server.rsapublickey_exportable
-                    Some(&"pubkey") => {
-                        /* /keys/pubkey/ */
-                        response.insert(
-                            "pubkey".into(),
-                            common::RSA_PUBLICKEY_EXPORTABLE.into(),
-                        );
-
-                        res = common::json_response_content(
-                            200,
-                            "Success".to_string(),
-                            response,
-                        );
-
-                        info!("GET pubkey return 200 response.");
-                    }
-
-                    _ => {
-                        res = common::json_response_content(
-                            400,
-                            "Invalid value for keys".to_string(),
-                            Map::new(),
-                        );
-                    }
-                };
-
-            // qutoe request: response include quote and ima_measurement_list
-            } else if parameters.contains_key("quotes") {
-                // only one of these two is available, the other is None if it
-                // is not in the HashMap
-                let pcr_mask = parameters.get(&"mask");
-                let vpcr_mask = parameters.get(&"vmask");
-                let mut ima_mask: String;
-                let nonce = parameters.get(&"nonce");
-
-                // input not valied without nonce attribute
-                if let None = nonce {
-                    warn!("GET quote returning 400 response. nonce not provided as an HTTP parameter in request");
-                    res = common::json_response_content(
-                        400,
-                        "Bad Request".to_string(),
-                        Map::new(),
-                    );
-                } else {
-                    // check parameters, there all should be strictly alphanumeric
-                    let nouce_isalnum =
-                        nonce.unwrap().chars().all(char::is_alphanumeric);
-                    let pcr_isalnum =
-                        pcr_mask.unwrap().chars().all(char::is_alphanumeric);
-                    let vpcr_isalnum =
-                        vpcr_mask.unwrap().chars().all(char::is_alphanumeric);
-
-                    if !(nouce_isalnum
-                        && (pcr_mask == None || pcr_isalnum)
-                        && (vpcr_mask == None || vpcr_isalnum))
-                    {
-                        warn!("GET quote returning 400 response. parameters should be strictly alphanumeric");
-                        res = common::json_response_content(
-                            400,
-                            "Bad Request".to_string(),
-                            Map::new(),
-                        );
-                    } else {
-                        let mut quote: String;
-
-                        // identity quotes are always shallow
-                        if !tpm::is_vtpm().unwrap()
-                            || parameters.get(&"quotes").unwrap()
-                                == &"identity"
-                        {
-                            quote = tpm::create_quote(
-                                nonce.unwrap().to_string(),
-                                common::RSA_PUBLICKEY_EXPORTABLE.to_string(),
-                                pcr_mask.unwrap().to_string(),
-                            )
-                            .unwrap();
-                            // tpm quote placeholder
-                            ima_mask = pcr_mask.unwrap().to_string();
-                        } else {
-                            quote = tpm::create_deep_quote(
-                                nonce.unwrap().to_string(),
-                                common::RSA_PUBLICKEY_EXPORTABLE.to_string(),
-                                vpcr_mask.unwrap().to_string(),
-                                pcr_mask.unwrap().to_string(),
-                            )
-                            .unwrap();
-                            ima_mask = vpcr_mask.unwrap().to_string();
-                        }
-
-                        let mut response = Map::new();
-
-                        if parameters.contains_key(&"partial")
-                            && parameters.get(&"partial") == None
-                            || parameters.get(&"partial") == Some(&"1")
-                        {
-                            response.insert("quote".into(), quote.into());
-                        } else {
-                            response.insert("quote".into(), quote.into());
-                            response.insert(
-                                "pubkey".into(),
-                                common::RSA_PUBLICKEY_EXPORTABLE.into(),
-                            );
-                        }
-
-                        if tpm::check_mask(
-                            ima_mask.to_string(),
-                            common::IMA_PCR,
-                        ) {
-                            match common::STUB_IMA {
-                                true => {
-                                    let temp_path =
-                                        Path::new(common::IMA_ML_STUB);
-                                    if temp_path.exists() {
-                                        let buffer = read_in_file(
-                                            common::IMA_ML_STUB.to_string(),
-                                        );
-
-                                        let mut contents = String::new();
-                                        match buffer {
-                                            Ok(b) => contents = b,
-                                            Err(_) => {}
-                                        }
-                                        response.insert(
-                                            "ima_measurement_list".into(),
-                                            contents.into(),
-                                        );
-                                    } else {
-                                        warn!(
-                                            "IMA measurement list not available: {}",
-                                            common::IMA_ML_STUB,
-                                        );
-                                    }
-                                }
-
-                                false => {
-                                    let temp_path = Path::new(common::IMA_ML);
-                                    if temp_path.exists() {
-                                        let buffer = read_in_file(
-                                            common::IMA_ML.to_string(),
-                                        );
-
-                                        let mut contents = String::new();
-                                        match buffer {
-                                            Ok(b) => contents = b,
-                                            Err(_) => {}
-                                        }
-
-                                        response.insert(
-                                            "ima_measurement_list".into(),
-                                            contents.into(),
-                                        );
-                                    } else {
-                                        warn!(
-                                            "IMA measurement list not available: {}",
-                                            common::IMA_ML,
-                                        );
-                                    }
-                                }
-                            }
-                        }
-
-                        info!(
-                            "GET {} quote returning 200 response",
-                            parameters["quote"],
-                        );
-
-                        res = common::json_response_content(
-                            200,
-                            "Success".to_string(),
-                            response,
-                        );
-                    }
+            match get_request_handler(&mut my_response, parameters) {
+                Ok(()) => {
+                    info!("Get request handled successfully.");
                 }
-            } else {
-                warn!("Bad GET request for {}", req.uri());
-                res = common::json_response_content(
-                    400,
-                    "Fail".to_string(),
-                    Map::new(),
-                );
+
+                Err(e) => {
+                    error!("Failed to handle get request with error {}.", e);
+                }
             }
         }
 
-        &Method::POST => match parameters.get(&"keys") {
-            Some(&"ukey") => {
-                res = common::json_response_content(
-                    400,
-                    "Success".to_string(),
-                    Map::new(),
-                );
-                info!("adding u key");
+        &Method::POST => {
+            match post_request_handler(&mut my_response, parameters) {
+                Ok(()) => {
+                    info!("Post request handled successfully.");
+                }
+                Err(e) => {
+                    error!("Failed to handle post request with error {}.", e);
+                }
             }
-
-            Some(&"vkey") => {
-                res = common::json_response_content(
-                    400,
-                    "Success".to_string(),
-                    Map::new(),
-                );
-                info!("adding v key");
-            }
-
-            _ => {
-                warn!("Bad POST request to {}", req.uri());
-                res = common::json_response_content(
-                    400,
-                    "Fail".to_string(),
-                    Map::new(),
-                );
-            }
-        },
+        }
 
         _ => {
             warn!("Bad request type {}", req.uri());
-            let body = Body::from(NOTFOUND);
-            res = Response::builder()
-                .status(StatusCode::NOT_FOUND)
-                .body(body)
-                .unwrap();
+            *my_response.body_mut() = "Not Found.".into();
         }
     }
 
-    Box::new(future::ok(res))
+    Box::new(future::ok(my_response))
+}
+
+fn post_request_handler(
+    my_response: &mut Response<Body>,
+    parameters: HashMap<&str, &str>,
+) -> Result<(), Box<String>> {
+    let mut response_map = Map::new();
+    match parameters.get(&"keys") {
+        Some(&"ukey") => {
+            if let Err(e) = set_response_content(
+                200,
+                "Add u key",
+                response_map,
+                my_response,
+            ) {
+                return emsg(
+                    "Failed to edit the response content body.",
+                    Some(e),
+                );
+            }
+            Ok(())
+        }
+        Some(&"vkey") => {
+            if let Err(e) = set_response_content(
+                200,
+                "Add v key",
+                response_map,
+                my_response,
+            ) {
+                return emsg(
+                    "Failed to edit the response content body.",
+                    Some(e),
+                );
+            }
+            Ok(())
+        }
+        _ => {
+            if let Err(e) = set_response_content(
+                400,
+                "Bad Request",
+                response_map,
+                my_response,
+            ) {
+                return emsg(
+                    "Failed to edit the response content body.",
+                    Some(e),
+                );
+            }
+            emsg("Bad Request. Invalid post request.", None::<String>)
+        }
+    }
+}
+
+fn get_request_handler(
+    my_response: &mut Response<Body>,
+    parameters: HashMap<&str, &str>,
+) -> Result<(), Box<String>> {
+    info!("GET invoked");
+
+    // Invalid request handling
+    if parameters.is_empty() {
+        if let Err(e) = set_response_content(
+            400,
+            "Not Implemented: Use /v2/keys/ or /v2/quotes/ interfaces.",
+            Map::new(),
+            my_response,
+        ) {
+            return emsg(
+                "Failed to edit response content. Error {}.",
+                Some(e),
+            );
+        }
+        return emsg(
+            "Error: Invalid API request. Abort the handling process.",
+            None::<String>,
+        );
+    }
+
+    if parameters.contains_key("keys") {
+        let mut response_map = Map::new();
+
+        match parameters.get(&"keys") {
+            // Check K value is available to use the do_hmac function
+            // Crypto request will do hmac for the challenge
+            // PYthon version function : crypto.do_hmac(self.server.K, challenge)
+            Some(&"verify") => {
+                // Sample request: /keys/verify/challenge/foo
+                // retrieve challenge from the request body
+                let challenge = match parameters.get(&"challenge") {
+                    Some(c) => c,
+                    None => {
+                        if let Err(e) = set_response_content(
+                            400,
+                            "Challenge is missing.",
+                            response_map,
+                            my_response,
+                        ) {
+                            return emsg(
+                                "Failed to edit response content.",
+                                Some(e),
+                            );
+                        }
+                        return emsg("Error: Challenge is missing for verify reqeust. Abort the handling process.", None::<String>);
+                    }
+                };
+
+                // create hmac for the challenge
+                match crypto::do_hmac(
+                    common::KEY.to_string(),
+                    challenge.to_string(),
+                ) {
+                    Ok(hmac) => {
+                        response_map.insert("hmac".into(), hmac.into());
+                        if let Err(e) = set_response_content(
+                            200,
+                            "Success",
+                            response_map,
+                            my_response,
+                        ) {
+                            return emsg(
+                                "Failed to edit response content.",
+                                Some(e),
+                            );
+                        }
+                    }
+
+                    Err(e) => {
+                        if let Err(e) = set_response_content(
+                            400,
+                            "HMAC failed.",
+                            Map::new(),
+                            my_response,
+                        ) {
+                            return emsg(
+                                "Failed to edit response content. Error {}.",
+                                Some(e),
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Verify pubkey which is the exported rsa pub key
+            // Python version: self.server.rsapublickey_exportable
+            Some(&"pubkey") => {
+                // GET /keys/pubkey/
+                response_map.insert(
+                    "pubkey".into(),
+                    common::RSA_PUBLICKEY_EXPORTABLE.into(),
+                );
+
+                if let Err(e) = set_response_content(
+                    200,
+                    "Success",
+                    response_map,
+                    my_response,
+                ) {
+                    return emsg(
+                        "Failed to edit the response content body.",
+                        Some(e),
+                    );
+                }
+            }
+
+            _ => {
+                if let Err(e) = set_response_content(
+                    400,
+                    "Invalid request for keys",
+                    response_map,
+                    my_response,
+                ) {
+                    return emsg(
+                        "Failed to edit the response content. Error {}.",
+                        Some(e),
+                    );
+                }
+            }
+        }
+
+    // quote request: response include quote and ima_measurement_list
+    } else if parameters.contains_key("quotes") {
+        // Only one of these two is available, the other one is None\
+        let pcr_mask = parameters.get(&"mask");
+        let vpcr_mask = parameters.get(&"vmask");
+        let mut response_map = Map::new();
+        let mut ima_mask: String;
+        let nonce = parameters.get(&"nonce");
+
+        // If nonce is not available, it is an invalid request
+        if let None = nonce {
+            if let Err(e) = set_response_content(
+                400,
+                "Invalid reqeust",
+                response_map,
+                my_response,
+            ) {
+                return emsg("Failed to edit response content.", Some(e));
+            }
+            return emsg(
+                "GET quote returning 400 response. Nonce is not avaiable.",
+                None::<String>,
+            );
+        }
+
+        // verify all parameters is available inside the request body
+        let (n, p, v) = match (nonce, pcr_mask, vpcr_mask) {
+            (Some(n), Some(p), Some(v)) => (n, p, v),
+            _ => {
+                if let Err(e) = set_response_content(
+                    400,
+                    "Bad request",
+                    response_map,
+                    my_response,
+                ) {
+                    return emsg("Failed to edit response content.", Some(e));
+                }
+                return emsg("GET quote return 400 response. Bad request: nonce, pcr_mask, vpcr_mask can't be None.", None::<String>);
+            }
+        };
+
+        let nonce_isalnum = n.chars().all(char::is_alphanumeric);
+        let pcr_mask_isalnum = p.chars().all(char::is_alphanumeric);
+        let vpcr_mask_isalnum = v.chars().all(char::is_alphanumeric);
+
+        if !(nonce_isalnum
+            && (pcr_mask == None || pcr_mask_isalnum)
+            && (vpcr_mask == None || vpcr_mask_isalnum))
+        {
+            if let Err(e) = set_response_content(
+                 400,
+                 "Bad Request. Parameters should be strictly alphanumeric string.",
+                 response_map,
+                 my_response,
+                 ) {
+                 return emsg("Failed to edit the response content body.", Some(e));
+             }
+
+            return emsg("GET quote return 400 response. Parameters should all be strictly alphanumeric.", None::<String>);
+        }
+
+        let mut quote: String;
+        let vtpm_flag = tpm::is_vtpm();
+        let quotes = match parameters.get(&"quotes") {
+            Some(q) => q,
+            None => {
+                if let Err(e) = set_response_content(
+                    400,
+                    "Quote is missing in request.",
+                    response_map,
+                    my_response,
+                ) {
+                    return emsg(
+                        "Failed to edit response content body.",
+                        Some(e),
+                    );
+                }
+                return emsg(
+                    "Bad Request. Quote is missing in request.",
+                    None::<String>,
+                );
+            }
+        };
+
+        // identtity quotes are always shallow
+        if !vtpm_flag || quotes == &"identity" {
+            quote = match tpm::create_quote(
+                n.to_string(),
+                common::RSA_PUBLICKEY_EXPORTABLE.to_string(),
+                p.to_string(),
+            ) {
+                Some(q) => q,
+                None => {
+                    if let Err(e) = set_response_content(
+                        400,
+                        "Failed to crate quote from TPM.",
+                        response_map,
+                        my_response,
+                    ) {
+                        return emsg(
+                            "Faild to edit the response content body.",
+                            Some(e),
+                        );
+                    }
+                    return emsg(
+                        "TPM error. Failed to create quote from TPM.",
+                        None::<String>,
+                    );
+                }
+            };
+
+            ima_mask = p.to_string();
+        } else {
+            quote = match tpm::create_deep_quote(
+                n.to_string(),
+                common::RSA_PUBLICKEY_EXPORTABLE.to_string(),
+                v.to_string(),
+                p.to_string(),
+            ) {
+                Some(q) => q,
+                None => {
+                    if let Err(e) = set_response_content(
+                        400,
+                        "Failed to create deep quote from TPM.",
+                        response_map,
+                        my_response,
+                    ) {
+                        return emsg(
+                            "Failed to edit response content body.",
+                            Some(e),
+                        );
+                    }
+                    return emsg(
+                        "TPM error. Failed to create deep quote from TPM.",
+                        None::<String>,
+                    );
+                }
+            };
+
+            ima_mask = v.to_string();
+        }
+
+        if parameters.contains_key(&"partial")
+            && parameters.get(&"partial") == None
+            || parameters.get(&"partial") == Some(&"1")
+        {
+            response_map.insert("quote".into(), quote.into());
+        } else {
+            response_map.insert("quote".into(), quote.into());
+            response_map.insert(
+                "pubkey".into(),
+                common::RSA_PUBLICKEY_EXPORTABLE.into(),
+            );
+        }
+
+        if tpm::check_mask(ima_mask.to_string(), common::IMA_PCR) {
+            match common::STUB_IMA {
+                true => {
+                    let temp_path = Path::new(common::IMA_ML_STUB);
+                    if !temp_path.exists() {
+                        return emsg(
+                            "IMA measurement list not available.",
+                            None::<String>,
+                        );
+                    }
+                    let buffer =
+                        match read_in_file(common::IMA_ML_STUB.to_string()) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                return emsg(
+                                    "Failed to read IMA_ML_STUB file.",
+                                    Some(e),
+                                );
+                            }
+                        };
+
+                    let mut contents = String::new();
+                }
+                false => {
+                    let temp_path = Path::new(common::IMA_ML);
+                    if !temp_path.exists() {
+                        return emsg(
+                            "IMA measurement list not available.",
+                            None::<String>,
+                        );
+                    }
+                    let buffer =
+                        match read_in_file(common::IMA_ML.to_string()) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                return emsg(
+                                    "Failed to read IMA_ML file.",
+                                    Some(e),
+                                );
+                            }
+                        };
+
+                    response_map
+                        .insert("ima_measurement_list".into(), buffer.into());
+                }
+            }
+        }
+        if let Err(e) =
+            set_response_content(200, "Success", response_map, my_response)
+        {
+            return emsg("Failed to edit the response content body.", Some(e));
+        }
+    } else {
+        if let Err(e) =
+            set_response_content(400, "Bad Request.", Map::new(), my_response)
+        {
+            return emsg("Failed to edit the response content body.", Some(e));
+        }
+        return emsg("Bad Request. Invalid request content.", None::<String>);
+    }
+    Ok(())
 }
 
 /*


### PR DESCRIPTION
1. Removed all the unwraps for all the scripts under src/ directory except the testing suite.
2. Changes functions' return type to `Result<>` after removing the unwraps, which has better error handling.
3. Add a script to CI for catch a list of banned function that could possibly be panicking the thread and terminate the process. Both the shell script and the banned list are both `.travis/` directory.

The main change in main.rs is a loop scope is used to wrap around the request, once an error is encountered early exit the loop scope with the response that has the corresponding content regarding the error.

Now there should be now unwraps/panics in the repo and prevent further use of these panic function in this repo.