### PR TITLE
Add OpenSSL bindings for RSA public key import and random RSA key generation

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -5,8 +5,11 @@ extern crate openssl;
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkcs5;
-use openssl::pkey::PKey;
+use openssl::pkey::{PKey, Public};
+use openssl::rsa::Rsa;
 use openssl::sign::Signer;
+use std::fs::File;
+use std::io::Read;
 use std::string::String;
 
 /*
@@ -26,6 +29,23 @@ pub fn do_hmac(
     signer.update(message)?;
     let hmac = signer.sign_to_vec()?;
     Ok(to_hex_string(hmac))
+}
+
+/*
+ * Input: path to PEM-encoded RSA public key
+ * Output: OpenSSL RSA key object
+ *
+ * Import a PEM-encoded RSA public key and return a callable OpenSSL RSA key
+ * object.
+ */
+pub fn rsa_import_pubkey(
+    input_key_path: String,
+) -> Result<Rsa<Public>, ErrorStack> {
+    let mut key_buffer = vec![0; 1];
+    if let Ok(mut input_key) = File::open(input_key_path) {
+        input_key.read_to_end(&mut key_buffer);
+    }
+    Ok(Rsa::public_key_from_pem(&key_buffer)?)
 }
 
 /*

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -5,7 +5,7 @@ extern crate openssl;
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkcs5;
-use openssl::pkey::{PKey, Public};
+use openssl::pkey::{PKey, Private, Public};
 use openssl::rsa::Rsa;
 use openssl::sign::Signer;
 use std::fs::File;
@@ -46,6 +46,16 @@ pub fn rsa_import_pubkey(
         input_key.read_to_end(&mut key_buffer);
     }
     Ok(Rsa::public_key_from_pem(&key_buffer)?)
+}
+
+/*
+ * Input: desired key size
+ * Output: OpenSSL RSA key object
+ *
+ * Randomly generate a callable OpenSSL RSA key object with desired key size.
+ */
+pub fn rsa_generate(key_size: u32) -> Result<Rsa<Private>, ErrorStack> {
+    Ok(Rsa::generate(key_size)?)
 }
 
 /*

--- a/src/secure_mount.rs
+++ b/src/secure_mount.rs
@@ -61,7 +61,7 @@ fn mount() -> Result<String, i32> {
         if !secure_dir_path.exists() {
             match fs::create_dir(secure_dir_path) {
                 Ok(()) => {
-                    return Ok(secure_dir_path.to_str().unwrap().to_string())
+                    return Ok(secure_dir_path.to_str().unwrap().to_string());
                 }
                 Err(e) => {
                     error!("Failed to create directory, error {}", e);


### PR DESCRIPTION
This is a **work-in-progress** pull request that implements bindings for two crypto functions necessary for the implementation of the Keylime Rust client (as per @leonjia0112). These also constitute a part of the crypto interface as specified in #20. Documentation for both functions is included inline.

Some notes to keep in mind:
- Per offline discussion with @leonjia0112 and @frozencemetery, we will be building our own error type to reconcile the different varieties of error the entire client will be dealing with, as documented in #42. For this reason, error handling should be considered incomplete for these bindings -- with the expectation that the functions should be revised to work with the new error type once it's been implemented.
- Tests do not yet exist for either function -- they should be added in after we implement our own error variety as specified above.

Tagging @frozencemetery and @leonjia0112 for review.